### PR TITLE
Update custom-jupyter-kernel.rst

### DIFF
--- a/source/howto/custom-jupyter-kernel.rst
+++ b/source/howto/custom-jupyter-kernel.rst
@@ -29,7 +29,7 @@ If you do not already have one, you can create a terminal in Files, as a "Termin
 ::
 
     mkdir -p $HOME/.local/share/jupyter/kernels
-    cp -arv /ext/jupyter/kernels/sage-8.1 $HOME/.local/share/jupyter/kernels/sage_custom
+    cp -arv /ext/jupyter/kernels/sagemath $HOME/.local/share/jupyter/kernels/sage_custom
 
 3. Edit the ``kernel.json`` file copy of the kernel you made::
 


### PR DESCRIPTION
The old example used sage-8.1 which is no longer an available kernel so the example will failed. It has now been changed to sagemath which should always work.