### PR TITLE
Fixed broken links from smc-util to packages/util

### DIFF
--- a/source/api/get_available_upgrades.rst
+++ b/source/api/get_available_upgrades.rst
@@ -8,7 +8,7 @@ API key appears in the request. Two objects are returned, total upgrades
 and available upgrades.
 
 See
-https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/upgrade-spec.js
+https://github.com/sagemathinc/cocalc/blob/master/src/packages/util/upgrade-spec.ts
 for units
 
 Example:

--- a/source/api/index0.rst
+++ b/source/api/index0.rst
@@ -36,9 +36,9 @@ Additional References
 
 
 * The `CoCalc API tutorial <https://share.cocalc.com/share/6eec7a75ce704502e2d557f44c316bf75c5c6ce7/Public/?viewer=share>`_ illustrates API calls in Python.
-* The CoCalc PostgreSQL schema definition `src/smc-util/db-schema <https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/db-schema>`_ has information on tables and fields used with the API ``query`` request.
+* The CoCalc PostgreSQL schema definition `src/packages/util/db-schema <https://github.com/sagemathinc/cocalc/blob/master/src/packages/util/db-schema>`_ has information on tables and fields used with the API ``query`` request.
 * The API test suite `src/smc-hub/test/api/ <https://github.com/sagemathinc/cocalc/tree/master/src/smc-hub/test/api>`_ contains mocha unit tests for the API messages.
-* The CoCalc message definition file `src/smc-util/message.js <https://github.com/sagemathinc/cocalc/blob/master/src/smc-util/message.js>`_ contains the source for this guide.
+* The CoCalc message definition file `src/packages/util/message.js <https://github.com/sagemathinc/cocalc/blob/master/src/packages/util/message.js>`_ contains the source for this guide.
 
 API Message Reference
 ---------------------


### PR DESCRIPTION
While reading the docs, I found some broken links. I believe these are the current links to the most up-to-date filetree on CoCalc's main repo.